### PR TITLE
fixed lmfit nan_policy causing errors with lmfit>1.0.1

### DIFF
--- a/fluo/models.py
+++ b/fluo/models.py
@@ -72,7 +72,7 @@ class Model():
         """
         return GenericModel(
             self._model_function(**independent_var),
-            missing='drop',
+            missing='omit',
             name=self.name
             )
 
@@ -271,7 +271,7 @@ class AddConstant():
         """
         return GenericModel(
             self._model_function(**independent_var),
-            missing='drop',
+            missing='omit',
             name=self.name
             )
 
@@ -354,7 +354,7 @@ class Linearize():
         """
         return GenericModel(
             self._model_function(**independent_var),
-            missing='drop',
+            missing='omit',
             name=self.name)
 
     def _model_function(self, **independent_var):
@@ -464,7 +464,7 @@ class Convolve():
         """
         return GenericModel(
             self._model_function(**independent_var),
-            missing='drop',
+            missing='omit',
             name=self.name
             )
 


### PR DESCRIPTION
deprecated lmfit nan_policy 'drop' was removed in lmfit 1.0.1, causing lmfit to fail whenever there are NaNs in the data.